### PR TITLE
jsdoc ENOENT error + minor changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,21 +100,8 @@ Plugin.prototype.apply = function (compiler) {
         callback();
       }).catch((err) => {
         if (err.code === "ENOENT") {
-          /**
-           * Then try to spawn the jsdoc command from `node_modules/.bin` path
-           * assuming that process.cwd() points to the app root path.
-           */
-           return spawnJsDoc(`${process.cwd()}/node_modules/.bin`, obj)
-        } else {
-          return Promise.reject(err);
-        }
-      }).then((errs) => {
-        if (errs && errs.length > 0) compilation.errors = compilation.errors.concat(errs);
-        callback();
-      }).catch((err) => {
-        if (err.code === "ENOENT") {
             /**
-             * Finally try to spawn the global jsdoc command
+             * Finally try to let node find it
              */
             return spawnJsDoc(null, obj);
         } else {

--- a/index.js
+++ b/index.js
@@ -27,11 +27,16 @@ function spawnJsDoc (basePath, obj) {
     var spawnErr = false;
     var cwd = process.cwd();
     var jsDocConfTmp = path.resolve(cwd, 'jsdoc.' + Date.now() + '.conf.tmp');
+    var command = /^win/.test(process.platform) ? 'jsdoc.cmd' : 'jsdoc';
+    var jsdoc;
 
     fs.writeFileSync(jsDocConfTmp, JSON.stringify(obj));
 
-    var command = /^win/.test(process.platform) ? 'jsdoc.cmd' : 'jsdoc';
-    var jsdoc = spawn(path.resolve(basePath, command), ['-c', jsDocConfTmp]);
+    if (typeof basePath === 'string') {
+      jsdoc = spawn(path.resolve(basePath, command), ['-c', jsDocConfTmp])
+    } else {
+      jsdoc = spawn('jsdoc', ['-c', jsDocConfTmp])
+    }
 
     jsdoc.on('error', (err) => {
       spawnErr = err;
@@ -94,20 +99,36 @@ Plugin.prototype.apply = function (compiler) {
         if (errs && errs.length > 0) compilation.errors = compilation.errors.concat(errs);
         callback();
       }).catch((err) => {
-        if (err.code === 'ENOENT') {
-            /**
-             * Then if it wasn' found try to spawn it from the `node_modules/.bin` path,
-             * assuming that process.cwd() points to the app root path.
-             */
-            return spawnJsDoc(`${process.cwd()}/node_modules/.bin`, obj);
+        if (err.code === "ENOENT") {
+          /**
+           * Then try to spawn the jsdoc command from `node_modules/.bin` path
+           * assuming that process.cwd() points to the app root path.
+           */
+           return spawnJsDoc(`${process.cwd()}/node_modules/.bin`, obj)
         } else {
-          return Promise.resolve();
+          return Promise.reject(err);
         }
       }).then((errs) => {
         if (errs && errs.length > 0) compilation.errors = compilation.errors.concat(errs);
         callback();
       }).catch((err) => {
-        compilation.errors.push(err);
+        if (err.code === "ENOENT") {
+            /**
+             * Finally try to spawn the global jsdoc command
+             */
+            return spawnJsDoc(null, obj);
+        } else {
+          return Promise.reject(err);
+        }
+      }).then((errs) => {
+        if (errs && errs.length > 0) compilation.errors = compilation.errors.concat(errs);
+        callback();
+      }).catch((err) => {
+        if (err.code === "ENOENT") {
+          compilation.errors.push(new Error('JSDOC not found.'))
+        } else {
+          compilation.errors.push(err);
+        }
         callback();
       });
 


### PR DESCRIPTION
changes:
* search for the jsdoc command in both `node_modules/.bin` and `node_modules/jsdoc-webpack-plugin/node_modules/.bin`,
  given that different versions of npm could install a package nested or not (see https://github.com/npm/npm/issues/9809)
* push errors in the `compilation.errors` array for visualization when jsodc fails
* unlink temp file before returning from jsodc process completion