### PR TITLE
Apply to accept extra arguments, Fix ENOENT error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 jsdoc-webpack-plugin
 ==========================
 
-
 WebPack plugin that runs [jsdoc](http://usejsdoc.org/) on your bundles
 
 # Usage
 In webpack.config.js:
 ```javascript
-var webpack = require('webpack');
-var JsDocPlugin = require('jsdoc-webpack-plugin');
+const webpack = require('webpack');
+const JsDocPlugin = require('jsdoc-webpack-plugin');
 
 module.exports = {
     /// ... rest of config
     plugins: [
         new JsDocPlugin({
-            args: [rootPath + '/README.md', '-r'],
+            args: ['-r'],
             conf: './jsdoc.conf'
         })
     ]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ module.exports = {
     /// ... rest of config
     plugins: [
         new JsDocPlugin({
-            args: ['-r'],
+            extraArgs: ['-r'],
             conf: './jsdoc.conf'
         })
     ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ module.exports = {
     /// ... rest of config
     plugins: [
         new JsDocPlugin({
+            args: [rootPath + '/README.md', '-r'],
             conf: './jsdoc.conf'
         })
     ]

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var fsExtra = require('fs-extra');
 
 function Plugin(translationOptions) {
   var defaultOptions = {
+    args: [],
     conf: './jsdoc.conf'
   };
 
@@ -51,10 +52,12 @@ Plugin.prototype.apply = function (compiler) {
       var jsDocConfTmp = path.resolve(cwd, 'jsdoc.' + Date.now() + '.conf.tmp');
       fs.writeFileSync(jsDocConfTmp, JSON.stringify(obj));
 
-        if(/^win/.test(process.platform))
-            jsdoc = spawn(__dirname + '/node_modules/.bin/jsdoc.cmd', ['-c', jsDocConfTmp]);
-        else
-            jsdoc = spawn(__dirname + '/node_modules/.bin/jsdoc', ['-c', jsDocConfTmp]);
+      var args = ['-c', jsDocConfTmp].concat(options.args);
+
+      if(/^win/.test(process.platform))
+        jsdoc = spawn(__dirname + '/node_modules/.bin/jsdoc.cmd', args);
+      else
+        jsdoc = spawn(__dirname + '/node_modules/.bin/jsdoc', args);
 
       jsdoc.stdout.on('data', function (data) {
         console.log(data.toString());

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "homepage": "https://github.com/tfiwm/jsdoc-webpack-plugin#readme",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "jsdoc": "^3.4.0",
-    "lodash": "^4.11.2"
+    "jsdoc": "^3.4.0"
   }
 }


### PR DESCRIPTION
Can be adding extra arguments like this,

```javascript
new JsDocPlugin({
  extraArgs: ['-r'],
  conf: `${buildPath}/jsdoc.json`
})
```

Also, the plugin code transform to ES2015 syntax.