### PR TITLE
Fix issue with npm3 flat dependency structure on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ Plugin.prototype.apply = function (compiler) {
       fs.writeFileSync(jsDocConfTmp, JSON.stringify(obj));
 
         if(/^win/.test(process.platform))
-            jsdoc = spawn(__dirname + '/node_modules/.bin/jsdoc.cmd', ['-c', jsDocConfTmp]);
+            jsdoc = spawn(path.resolve(cwd) + '/node_modules/.bin/jsdoc.cmd', ['-c', jsDocConfTmp]);
         else
             jsdoc = spawn(__dirname + '/node_modules/.bin/jsdoc', ['-c', jsDocConfTmp]);
 


### PR DESCRIPTION
This fixes the issue with npm3's new way of storing dependencies to limit nested node_modules folders.

Thank you [JarvisH](https://github.com/tfiwm/jsdoc-webpack-plugin/issues/11#issuecomment-341982356).