### PR TITLE
Release 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ module.exports = {
     /// ... rest of config
     plugins: [
         new JsDocPlugin({
-            conf: './jsdoc.conf'
+            conf: 'jsdoc.conf',
+            cwd: '.',
+            preserveTmpFile: false
         })
     ]
 }
@@ -24,4 +26,4 @@ module.exports = {
 There are two ways how this plugin recognizes the files
 
 1. It takes the information from the jsdoc config file "source.include"
-2. If no "source.include" provided, it takes the whole files from your bundles
+2. If no "source.include" provided, it takes the whole files from your bundles and creates a temporary file

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ module.exports = {
     /// ... rest of config
     plugins: [
         new JsDocPlugin({
-            conf: 'jsdoc.conf',
+            conf: 'jsdoc.conf.js',
             cwd: '.',
             preserveTmpFile: false
         })

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ module.exports = {
 There are two ways how this plugin recognizes the files
 
 1. It takes the information from the jsdoc config file "source.include"
-2. If no "source.include" provided, it takes the whole files from your bundles and creates a temporary file
+2. If no "source.include" provided, it takes the original files from your bundles and creates a temporary file

--- a/index.js
+++ b/index.js
@@ -1,15 +1,84 @@
-var fs = require('fs');
 var path = require('path');
-var merge = require('lodash/merge');
 var spawn = require('child_process').spawn;
-var fsExtra = require('fs-extra');
+var fse = require('fs-extra');
+var _ = require('lodash');
 
-function Plugin(translationOptions) {
+/** @type {boolean} */
+var isWindows = /^win/.test(process.platform);
+
+/**
+ * Ordered paths to the jsdoc command.
+ *
+ * @type {string[]}
+ * @const
+ */
+var JSDOC_FILES = isWindows ? [
+  'node_modules/.bin/jsdoc.cmd'
+] : [
+  'node_modules/.bin/jsdoc',
+  'node_modules/jsdoc/jsdoc.js'
+];
+
+/**
+ * Looks up for an existing file in each directory.
+ *
+ * @param {string|string[]} [files=[files]] - Filenames in order.
+ * @param {string|string[]} [dirs=[dirs]] - Directories in order.
+ * @returns {?string} The first found file or `null` if nothing is found.
+ */
+var lookupFile = function (files, dirs) {
+  var found = null;
+
+  [].concat(files).some(function (filename) {
+    return [].concat(dirs).some(function (dirname) {
+      var file = path.resolve(path.join(dirname, filename));
+
+      if (fse.existsSync(file)) {
+        return found = file;
+      }
+    });
+  });
+
+  return found;
+};
+
+/**
+ * Reads the jsdoc config file (synchronously) allowing the use of CommonJS
+ * modules or JSON documents as input.
+ *
+ * @param {string} filepath - The filepath to read from.
+ * @throws If the file does not exist or is malformed.
+ * @return {object} The exported value.
+ */
+var readConfigFile = function (filepath) {
+  delete require.cache[filepath];
+  return require(filepath);
+};
+
+function Plugin(options) {
   var defaultOptions = {
-    conf: './jsdoc.conf'
+    /**
+     * Default name for the config file.
+     * A relative path to "cwd" is expected.
+     * @type {?string}
+     */
+    conf: 'jsdoc.conf',
+    /**
+     * Default path for command and file lookup.
+     * @type {?string}
+     */
+    cwd: '.',
+    /**
+     * This option applies only if a config file is not found.
+     * By default, the temp file is removed after the compilation
+     * is done, but you can set this option to a truthy value to
+     * change it.
+     * @type {?boolean}
+     */
+    preserveTmpFile: false
   };
 
-  this.options = merge({}, defaultOptions, translationOptions);
+  this.options = _.merge({}, defaultOptions, options);
 }
 
 Plugin.prototype.apply = function (compiler) {
@@ -22,60 +91,93 @@ Plugin.prototype.apply = function (compiler) {
   });
 
   compiler.plugin('emit', function (compilation, callback) {
+    var cwd = process.cwd();
+    var givenDirectory = options.cwd;
+    var preserveTmpFile = options.preserveTmpFile;
+    var jsdocConfig = path.resolve(givenDirectory, options.conf);
+    var jsdocConfigDir = path.dirname(jsdocConfig);
+    var files = [], jsdocErrors = [];
+    var obj = {};
+    var jsdoc, cmd;
+    var tmpFile;
+
     console.log('JSDOC Start generating');
 
-    fsExtra.readJson(path.resolve(process.cwd(), options.conf), function (err, obj) {
-      var files = [], jsdocErrors = [];
-      var jsdoc, cwd = process.cwd();
+    cmd = lookupFile(JSDOC_FILES, [
+      // 1. Where the config lives.
+      jsdocConfigDir,
+      // 2. In the given directory.
+      givenDirectory,
+      // 3. Where it was called.
+      cwd,
+      // 4. Here.
+      __dirname
+    ]);
 
-      if(err) {
-        callback(err);
+    if (!cmd) {
+      callback(new Error('jsdoc was not found.'));
+      return;
+    }
+
+    if (fse.existsSync(jsdocConfig)) {
+      try {
+        obj = readConfigFile(jsdocConfig);
+      } catch (exception) {
+        callback(exception);
         return;
       }
+    }
 
-      if (obj.source && obj.source.include) {
-        console.log('Taking sources from config file');
-      } else {
-        compilation.chunks.forEach(function (chunk) {
-          chunk.modules.forEach(function (module) {
-            if (module.fileDependencies) {
-              module.fileDependencies.forEach(function (filepath) {
-                files.push(path.relative(process.cwd(), filepath));
-              });
-            }
-          });
+    if (obj.source && obj.source.include) {
+      console.log('Taking sources from config file');
+    }
+    else {
+      compilation.chunks.forEach(function (chunk) {
+        chunk.modules.forEach(function (module) {
+          if (module.fileDependencies) {
+            module.fileDependencies.forEach(function (filepath) {
+              files.push(path.relative(process.cwd(), filepath));
+            });
+          }
         });
-        merge(obj.source, { include: files });
+      });
+      _.merge(obj.source, { include: files });
+
+      tmpFile = jsdocConfig + '.tmp';
+      console.log('Writing temporary file at: ', tmpFile);
+      fse.writeFileSync(tmpFile, JSON.stringify(obj));
+      jsdocConfig = tmpFile;
+    }
+
+    console.log('Using jsdoc located at: ', cmd);
+    jsdoc = spawn(cmd, ['-c', jsdocConfig], {
+      cwd: jsdocConfigDir
+    });
+
+    jsdoc.stdout.on('data', function (data) {
+      console.log(data.toString());
+    });
+
+    jsdoc.stderr.on('data', function (data) {
+      jsdocErrors.push(data.toString());
+    });
+
+    jsdoc.on('close', function (code) {
+      if (tmpFile && !preserveTmpFile) {
+        console.log('Removing the temporary file');
+        fse.unlinkSync(tmpFile);
+        tmpFile = null;
       }
 
-      var jsDocConfTmp = path.resolve(cwd, 'jsdoc.' + Date.now() + '.conf.tmp');
-      fs.writeFileSync(jsDocConfTmp, JSON.stringify(obj));
-
-        if(/^win/.test(process.platform))
-            jsdoc = spawn(path.resolve(cwd) + '/node_modules/.bin/jsdoc.cmd', ['-c', jsDocConfTmp]);
-        else
-            jsdoc = spawn(__dirname + '/node_modules/.bin/jsdoc', ['-c', jsDocConfTmp]);
-
-      jsdoc.stdout.on('data', function (data) {
-        console.log(data.toString());
-      });
-
-      jsdoc.stderr.on('data', function (data) {
-        jsdocErrors.push(data.toString());
-      });
-
-      jsdoc.on('close', function (data, code) {
-        if(jsdocErrors.length > 0) {
-          jsdocErrors.forEach(function (value) {
-            console.error(value);
-          });
-        } else {
-          console.log('JsDoc successful');
-        }
-        fs.unlink(jsDocConfTmp, function() {
-          callback();
+      if(jsdocErrors.length > 0) {
+        jsdocErrors.forEach(function (value) {
+          console.error(value);
         });
-      });
+        callback(new Error('JsDoc exited with code ' + code));
+      } else {
+        console.log('JsDoc successful');
+        callback();
+      }
     });
   });
 

--- a/index.js
+++ b/index.js
@@ -132,16 +132,27 @@ Plugin.prototype.apply = function (compiler) {
       console.log('Taking sources from config file');
     }
     else {
-      compilation.chunks.forEach(function (chunk) {
-        chunk.modules.forEach(function (module) {
-          if (module.fileDependencies) {
-            module.fileDependencies.forEach(function (filepath) {
-              files.push(path.relative(process.cwd(), filepath));
-            });
-          }
-        });
+      /**
+       * Pushes all filepaths included in the bundles (except any file from
+       * node_modules, like the webpack ones) into `files`.
+       * I.e:
+       *     If you use the scripts "a", "b" and expect webpack to bundle them to "main",
+       *     then the included files will be "a" and "b"...
+       *     NOT "main" and/or any file from "node_modules".
+       */
+      compilation.fileDependencies.forEach(function (filepath, i) {
+        var exception = /\/node_modules\//.test(filepath);
+
+        if (!exception) {
+          files.push(filepath);
+        }
       });
-      _.merge(obj.source, { include: files });
+
+      _.defaults(obj, {
+        source: {
+          include: files
+        }
+      });
 
       tmpFile = jsdocConfig + '.tmp';
       console.log('Writing temporary file at: ', tmpFile);

--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@ var spawn = require('child_process').spawn;
 var fse = require('fs-extra');
 var _ = require('lodash');
 
+/** @type {string} */
+var PLUGIN_NAME = 'JsDocPlugin';
+
 /** @type {boolean} */
 var isWindows = /^win/.test(process.platform);
 
@@ -85,12 +88,11 @@ Plugin.prototype.apply = function (compiler) {
   var self = this;
   var options = self.options;
 
-  compiler.plugin('watch-run', function (watching, callback) {
+  compiler.hooks.watchRun.tap(PLUGIN_NAME, function (watching) {
     self.webpackIsWatching = true;
-    callback(null, null);
   });
 
-  compiler.plugin('emit', function (compilation, callback) {
+  compiler.hooks.emit.tapAsync(PLUGIN_NAME, function (compilation, callback) {
     var cwd = process.cwd();
     var givenDirectory = options.cwd;
     var preserveTmpFile = options.preserveTmpFile;
@@ -192,7 +194,7 @@ Plugin.prototype.apply = function (compiler) {
     });
   });
 
-  compiler.plugin('done', function (stats) {
+  compiler.hooks.done.tap(PLUGIN_NAME, function (stats) {
     console.log('JSDOC Finished generating');
     console.log('JSDOC TOTAL TIME:', stats.endTime - stats.startTime);
   });

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function Plugin(options) {
      * A relative path to "cwd" is expected.
      * @type {?string}
      */
-    conf: 'jsdoc.conf',
+    conf: 'jsdoc.conf.js',
     /**
      * Default path for command and file lookup.
      * @type {?string}


### PR DESCRIPTION
Hi, there.

I found some issues while using your code and I decided to make some changes in order to (hopefully) fix some known issues, like #15 and any other that has to do with the ENOENT error. Also, it improves some other things.

I tested everything in webpack 4.36.1 and found that:
- I can't generate documentation without a config file.
- A temporary file is always created, and if something fails, the file will persist and won't be removed.
- An ENOENT error will occur if the path is not correct.
- I can't use a CJS module for jsdoc, which is valid for versions greater than 3.5.0.

So, this branch seems to fix all of that, but I don't know which one are the requirements for the supported versions or anything like that. 

I decided to be this the release 0.2.0 but it might break support for older versions of webpack, so it's up to you if you change it to 1.0.0.

Could you please test it and tell me if something fails or anything like that? I didn't test it on windows, but it should be fine.

Thank you in advance.