### PR TITLE
docs: remove link to phishing site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ jsdoc-webpack-plugin
 ==========================
 
 
-WebPack plugin that runs [jsdoc](http://usejsdoc.org/) on your bundles
+WebPack plugin that runs [jsdoc](https://jsdoc.app/) on your bundles
 
 # Usage
 In webpack.config.js:


### PR DESCRIPTION
Old link is jumping to some sketchy phishing site so seems higher priority than just a dead link.